### PR TITLE
Fixes string formatting in HealthCheckResult

### DIFF
--- a/Src/Metrics.Tests/HealthChecksTests/HealthCheckTests.cs
+++ b/Src/Metrics.Tests/HealthChecksTests/HealthCheckTests.cs
@@ -40,6 +40,20 @@ namespace Metrics.Tests.HealthChecksTests
             new HealthCheck(name, () => { ThrowException(); HealthCheckResult.Healthy(); }).Execute().Check.IsHealthy.Should().BeFalse();
         }
 
+        private static void ThrowExceptionWithBracketsInMessage()
+        {
+            throw new InvalidOperationException("an {example message}");
+        }
+
+        [Fact]
+        public void HealthCheck_FailedAndDoesNotThrowUnhandledExceptionIfActionThrowsExceptionWithBracketsInMessage()
+        {
+            string name = "test";
+            new HealthCheck(name, () => ThrowExceptionWithBracketsInMessage()).Execute().Check.IsHealthy.Should().BeFalse();
+            new HealthCheck(name, () => { ThrowExceptionWithBracketsInMessage(); return "string"; }).Execute().Check.IsHealthy.Should().BeFalse();
+            new HealthCheck(name, () => { ThrowExceptionWithBracketsInMessage(); HealthCheckResult.Healthy(); }).Execute().Check.IsHealthy.Should().BeFalse();
+        }
+
         [Fact]
         public void HealthCheck_FailedIfResultUnhealthy()
         {

--- a/Src/Metrics/HealthCheckResult.cs
+++ b/Src/Metrics/HealthCheckResult.cs
@@ -75,7 +75,7 @@ namespace Metrics
         public static HealthCheckResult Unhealthy(Exception exception)
         {
             var status = string.Format("EXCEPTION: {0} - {1}", exception.GetType().Name, exception.Message);
-            return HealthCheckResult.Unhealthy(status + Environment.NewLine + FormatStackTrace(exception));
+            return new HealthCheckResult(false, status + Environment.NewLine + FormatStackTrace(exception));
         }
 
         private static string FormatStackTrace(Exception exception, int indent = 2)


### PR DESCRIPTION
### From commit message
Fixes the `HealthCheckResult.Unhealthy(Exception)` overload when handling
exceptions which contain messages having curly braces (`{` and
`}`). These messages were being passed to `string.Format` and causing a
format exception. I changed the method to call the `HealthCheckResult`
constructor directly instead of the other overload that accepts a format
string.

Includes new test which was previously failing without this change to
`HealthCheckResult`.

### Issue Details
I ran into this issue when my owin health checks endpoint would just stop responding. It was caused by an unhandled string format exception in the `HealthCheckResult` class, caused when an exception in a HealthCheck contains curly braces in its message text.