### PR TITLE
Backwards compatible ElasticSearch 2 support

### DIFF
--- a/Src/Metrics/ElasticSearch/ElasticSearchConfigExtensions.cs
+++ b/Src/Metrics/ElasticSearch/ElasticSearchConfigExtensions.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using Metrics.ElasticSearch;
 using Metrics.Reports;
-using System.Threading.Tasks;
-using System.Net;
-using System.Runtime.Serialization.Json;
-using System.IO;
-using System.Text;
 
 namespace Metrics
 {
@@ -13,20 +8,10 @@ namespace Metrics
     {
         public static MetricsReports WithElasticSearch(this MetricsReports reports, string host, int port, string index, TimeSpan interval)
         {
-            var uri = new Uri(string.Format(@"http://{0}:{1}/_bulk", host, port));
-            Task<ElasticSearchNodeInfo> nodeInfo = GetElasticSearchNodeInfoAsync(new Uri(string.Format(@"http://{0}:{1}", host, port)));
-            return reports.WithReport(new ElasticSearchReport(uri, index, nodeInfo), interval);
+            var bulkUri = new Uri(string.Format(@"http://{0}:{1}/_bulk", host, port));
+            var nodeInfoUri = new Uri(string.Format(@"http://{0}:{1}", host, port));
+            return reports.WithReport(new ElasticSearchReport(bulkUri, index, nodeInfoUri), interval);
         }
 
-        private async static Task<ElasticSearchNodeInfo> GetElasticSearchNodeInfoAsync(Uri uri) {
-            string json;
-            using (var client = new WebClient())
-            {
-                json = await client.DownloadStringTaskAsync(uri);
-            }
-            var deserializer = new DataContractJsonSerializer(typeof(ElasticSearchNodeInfo));
-            MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
-            return (ElasticSearchNodeInfo)deserializer.ReadObject(stream);
-        }
     }
 }

--- a/Src/Metrics/ElasticSearch/ElasticSearchConfigExtensions.cs
+++ b/Src/Metrics/ElasticSearch/ElasticSearchConfigExtensions.cs
@@ -1,6 +1,11 @@
 ﻿using System;
 using Metrics.ElasticSearch;
 using Metrics.Reports;
+using System.Threading.Tasks;
+using System.Net;
+using System.Runtime.Serialization.Json;
+using System.IO;
+using System.Text;
 
 namespace Metrics
 {
@@ -9,7 +14,19 @@ namespace Metrics
         public static MetricsReports WithElasticSearch(this MetricsReports reports, string host, int port, string index, TimeSpan interval)
         {
             var uri = new Uri(string.Format(@"http://{0}:{1}/_bulk", host, port));
-            return reports.WithReport(new ElasticSearchReport(uri, index), interval);
+            Task<ElasticSearchNodeInfo> nodeInfo = GetElasticSearchNodeInfoAsync(new Uri(string.Format(@"http://{0}:{1}", host, port)));
+            return reports.WithReport(new ElasticSearchReport(uri, index, nodeInfo), interval);
+        }
+
+        private async static Task<ElasticSearchNodeInfo> GetElasticSearchNodeInfoAsync(Uri uri) {
+            string json;
+            using (var client = new WebClient())
+            {
+                json = await client.DownloadStringTaskAsync(uri);
+            }
+            var deserializer = new DataContractJsonSerializer(typeof(ElasticSearchNodeInfo));
+            MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            return (ElasticSearchNodeInfo)deserializer.ReadObject(stream);
         }
     }
 }

--- a/Src/Metrics/ElasticSearch/ElasticSearchNodeInfo.cs
+++ b/Src/Metrics/ElasticSearch/ElasticSearchNodeInfo.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Metrics.ElasticSearch
+{
+
+    [DataContract]
+    public class ElasticSearchNodeInfo
+    {
+
+        [DataMember]
+        Version version = null;
+
+        public int MajorVersionNumber 
+        { 
+            get 
+            {
+                var major = version.Number.Substring(0, version.Number.IndexOf('.'));
+                return int.Parse(major);
+            } 
+        }
+    }
+
+    [DataContract]
+    class Version
+    {
+        [DataMember]
+        string number = "";
+
+        public string Number { get { return number; } }
+
+    }
+}

--- a/Src/Metrics/Metrics.csproj
+++ b/Src/Metrics/Metrics.csproj
@@ -43,6 +43,8 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SharedAssemblyInfo.cs">
@@ -56,6 +58,7 @@
     <Compile Include="Core\DefaultDataProvider.cs" />
     <Compile Include="Core\DefaultRegistryDataProvider.cs" />
     <Compile Include="ElasticSearch\ElasticSearchConfigExtensions.cs" />
+    <Compile Include="ElasticSearch\ElasticSearchNodeInfo.cs" />
     <Compile Include="ElasticSearch\ElasticSearchReport.cs" />
     <Compile Include="Graphite\PickleGraphiteSender.cs" />
     <Compile Include="Graphite\PickleJar.cs" />


### PR DESCRIPTION
ElasticSearch 2.0 doesn't support dotted field names as "Percentile 99.9%". We've previously replaced all dots in metric fields with "_", but that breaks reports people already had. For more info, check [this PR](https://github.com/etishor/Metrics.NET/pull/114) in the original repository.

Now a single request is fired to get the ElasticSearch version. It it fails or the version is < 2 we use dotted fields, otherwise they are replaced with underscores.