### PR TITLE
Fix issue with Graphite reports writing Count to Percent and Percent to Count for Meters

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Metrics.NET - a .NET Port, with lots of additional functionality, of the awesome
 
 A lot more [information and documentation are available in the wiki](https://github.com/etishor/Metrics.NET/wiki).
 
+**Note:** this repo is no longer being actively maintained. See [Recognos/Metrics.NET](https://github.com/Recognos/Metrics.NET) for a continuation of the project.
+
 ## License
 This library will always keep the same license as the original [Java Metrics library](https://github.com/dropwizard/metrics) (as long as its an open source, permisive license). This port is also inspired and contains some code from [Daniel Crenna's port](https://github.com/danielcrenna/metrics-net).
 

--- a/Src/Metrics/Graphite/GraphiteReport.cs
+++ b/Src/Metrics/Graphite/GraphiteReport.cs
@@ -64,8 +64,8 @@ namespace Metrics.Graphite
 
             foreach (var item in value.Items)
             {
-                Send(SubfolderName(name, unit, item.Item, "Count"), item.Percent);
-                Send(SubfolderName(name, unit, item.Item, "Percent"), item.Value.Count);
+                Send(SubfolderName(name, unit, item.Item, "Count"), item.Value.Count);
+                Send(SubfolderName(name, unit, item.Item, "Percent"), item.Percent);
                 Send(SubfolderName(name, AsRate(unit, rateUnit), item.Item, "Rate-Mean"), item.Value.MeanRate);
                 Send(SubfolderName(name, AsRate(unit, rateUnit), item.Item, "Rate-1-min"), item.Value.OneMinuteRate);
                 Send(SubfolderName(name, AsRate(unit, rateUnit), item.Item, "Rate-5-min"), item.Value.FiveMinuteRate);


### PR DESCRIPTION
The Graphite reports for Meters are writing the wrong values to the Count and Percent items.

Not sure how to only include one file in the pull request.