### PR TITLE
TimerMetric now save userValue in Meter

### DIFF
--- a/Src/Metrics/Core/TimerMetric.cs
+++ b/Src/Metrics/Core/TimerMetric.cs
@@ -44,7 +44,7 @@ namespace Metrics.Core
             if (nanos >= 0)
             {
                 this.histogram.Update(nanos, userValue);
-                this.meter.Mark();
+                this.meter.Mark(userValue);
                 this.totalRecordedTime.Add(nanos);
             }
         }


### PR DESCRIPTION
fix bug in Timer

Timer - composite class containing Meter and Histogram, but save userValue only in Histogram. This pull request fix it