### PR TITLE
Enable updating health checks

### DIFF
--- a/Src/Metrics/Core/HealthCheck.cs
+++ b/Src/Metrics/Core/HealthCheck.cs
@@ -16,7 +16,7 @@ namespace Metrics.Core
             }
         }
 
-        private readonly Func<HealthCheckResult> check;
+        internal Func<HealthCheckResult> CheckFunc { get; set; }
 
         protected HealthCheck(string name)
             : this(name, () => { })
@@ -33,14 +33,14 @@ namespace Metrics.Core
         public HealthCheck(string name, Func<HealthCheckResult> check)
         {
             this.Name = name;
-            this.check = check;
+            this.CheckFunc = check;
         }
 
         public string Name { get; }
 
         protected virtual HealthCheckResult Check()
         {
-            return this.check();
+            return this.CheckFunc();
         }
 
         public Result Execute()

--- a/Src/Metrics/HealthChecks.cs
+++ b/Src/Metrics/HealthChecks.cs
@@ -79,7 +79,19 @@ namespace Metrics
         /// <param name="healthCheck">Custom health check to register.</param>
         public static void RegisterHealthCheck(HealthCheck healthCheck)
         {
-            checks.TryAdd(healthCheck.Name, healthCheck);
+            bool added = checks.TryAdd(healthCheck.Name, healthCheck);
+            if (!added)
+            {
+                HealthCheck existingHealthCheck;
+                if (checks.TryGetValue(healthCheck.Name, out existingHealthCheck))
+                    existingHealthCheck.CheckFunc = healthCheck.CheckFunc;
+            }
+        }
+
+        public static void UnregisterHealthCheck(string healthCheckName)
+        {
+            HealthCheck healthCheck;
+            checks.TryRemove(healthCheckName, out healthCheck);
         }
 
         /// <summary>


### PR DESCRIPTION
We needed the ability to change the health-check function while program is running.

On current implementation, once you register the health-check function, you cannot change it any more. 
It is stored in the dictionary, and even if you try to register a new function on the same name, it will not be registered, since there already exists another function registered on the same name (The "TryAdd" on the dictionary will return false, and nothing will happen)
For instance, If the check function is contained in some object, and the object is disposed or its reference is lost, you have no ability to control the health-check function any more.

For this purpose, I added two new features:
1. There is a way to unregister just one check-function (by registration name), with no need to unregister all health checks
2. If someone tries to register a new check-function under the same name, it will override the current check-function, and registration will succeed.