### PR TITLE
Support GraphiteReporter configuration from app.config

### DIFF
--- a/Src/Metrics/Graphite/GraphiteExtensions.cs
+++ b/Src/Metrics/Graphite/GraphiteExtensions.cs
@@ -1,11 +1,15 @@
 ﻿using System;
+using System.Configuration;
 using Metrics.Graphite;
+using Metrics.Logging;
 using Metrics.Reports;
 
 namespace Metrics
 {
     public static class GraphiteExtensions
     {
+        private static readonly ILog log = LogProvider.GetCurrentClassLogger();
+
         public static MetricsReports WithGraphite(this MetricsReports reports, Uri graphiteUri, TimeSpan interval)
         {
             if (graphiteUri.Scheme.ToLowerInvariant() == "net.tcp")
@@ -44,6 +48,38 @@ namespace Metrics
         public static MetricsReports WithGraphite(this MetricsReports reports, GraphiteSender graphiteLink, TimeSpan interval)
         {
             return reports.WithReport(new GraphiteReport(graphiteLink), interval);
+        }
+
+        public static void WithGraphiteFromConfig(this MetricsReports reports)
+        {
+            try
+            {
+                var graphiteMetricsUri = ConfigurationManager.AppSettings["Metrics.Graphite.Uri"];
+                var graphiteMetricsInterval = ConfigurationManager.AppSettings["Metrics.Graphite.Interval.Seconds"];
+
+                if (!string.IsNullOrEmpty(graphiteMetricsUri) && !string.IsNullOrEmpty(graphiteMetricsInterval))
+                {
+                    Uri uri;
+                    int seconds;
+                    if (Uri.TryCreate(graphiteMetricsUri, UriKind.Absolute, out uri) && int.TryParse(graphiteMetricsInterval, out seconds) && seconds > 0)
+                    {
+                        reports.WithGraphite(uri, TimeSpan.FromSeconds(seconds));
+                        log.Debug(() => $"Metrics: Sending Graphite reports to {uri} every {seconds} seconds.");
+                    }
+                    else
+                    {
+                        log.Error(() => "Invalid Metrics Configuration: Metrics.Graphite.Uri must be a valid absolute URI and Metrics.Graphite.Interval.Seconds must be an integer > 0");
+                    }
+                }
+                else
+                {
+                    log.Warn(() => "Invalid Metrics Configuration: Metrics.Graphite.Uri must be a valid absolute URI and Metrics.Graphite.Interval.Seconds must be an integer > 0");
+                }
+            }
+            catch (Exception x)
+            {
+                MetricsErrorHandler.Handle(x, "Error while configuring graphite from config");
+            }
         }
     }
 }

--- a/Src/Metrics/MetricsConfig.cs
+++ b/Src/Metrics/MetricsConfig.cs
@@ -248,7 +248,6 @@ namespace Metrics
             {
                 ConfigureCsvReports();
                 ConfigureHttpListener();
-                ConfigureGraphiteReporter();
             }
         }
 
@@ -289,30 +288,6 @@ namespace Metrics
             catch (Exception x)
             {
                 MetricsErrorHandler.Handle(x, "Invalid Metrics Configuration: Metrics.CSV.Path must be a valid path and Metrics.CSV.Interval.Seconds must be an integer > 0 ");
-            }
-        }
-
-        private void ConfigureGraphiteReporter()
-        {
-            try
-            {
-                var graphiteMetricsUri = ConfigurationManager.AppSettings["Metrics.Graphite.Uri"];
-                var graphiteMetricsInterval = ConfigurationManager.AppSettings["Metrics.Graphite.Interval.Seconds"];
-
-                if (!string.IsNullOrEmpty(graphiteMetricsUri) && !string.IsNullOrEmpty(graphiteMetricsInterval))
-                {
-                    Uri uri;
-                    int seconds;
-                    if (Uri.TryCreate(graphiteMetricsUri, UriKind.Absolute, out uri) && int.TryParse(graphiteMetricsInterval, out seconds) && seconds > 0)
-                    {
-                        WithReporting(c => c.WithGraphite(uri, TimeSpan.FromSeconds(seconds)));
-                        log.Debug(() => $"Metrics: Sending Graphite reports to {uri} every {seconds} seconds.");
-                    }
-                }
-            }
-            catch (Exception x)
-            {
-                throw new InvalidOperationException("Invalid Metrics Configuration: Metrics.Graphite.Uri must be a valid absolute URI and Metrics.Graphite.Interval.Seconds must be an integer > 0 ", x);
             }
         }
 


### PR DESCRIPTION
Hello guys!

Now I have to configure GraphiteReporter from app.config inside my project, becauase Metrics.Net supports only CSVReporter configuration.

Here is an attempt to do GraphiteReporter configuration inside Metrics.Net as it's done for CSVReporter.