### PR TITLE
Use Task.Run instead of Task.Factory.StartNew

### DIFF
--- a/Src/Metrics/Metrics.csproj
+++ b/Src/Metrics/Metrics.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Utils\HostResolver.cs" />
     <Compile Include="Utils\IHideObjectMembers.cs" />
     <Compile Include="Utils\Scheduler.cs" />
+    <Compile Include="Utils\TaskEx.cs" />
     <Compile Include="Utils\TimeUnitExtensions.cs" />
     <Compile Include="Endpoints\AbstractMetricsEndpointHandler.cs" />
     <Compile Include="Endpoints\FlotWebApp.cs" />

--- a/Src/Metrics/Utils/ActionScheduler.cs
+++ b/Src/Metrics/Utils/ActionScheduler.cs
@@ -41,13 +41,13 @@ namespace Metrics.Utils
             Start(interval, t =>
             {
                 action(t);
-                return Task.FromResult(true);
+                return TaskEx.CompletedTask;
             });
         }
 
         public void Start(TimeSpan interval, Func<Task> action)
         {
-            Start(interval, t => t.IsCancellationRequested ? action() : Task.FromResult(true));
+            Start(interval, t => t.IsCancellationRequested ? action() : TaskEx.CompletedTask);
         }
 
         public void Start(TimeSpan interval, Func<CancellationToken, Task> action)

--- a/Src/Metrics/Utils/ActionScheduler.cs
+++ b/Src/Metrics/Utils/ActionScheduler.cs
@@ -69,7 +69,7 @@ namespace Metrics.Utils
 
         private static void RunScheduler(TimeSpan interval, Func<CancellationToken, Task> action, CancellationTokenSource token, int toleratedConsecutiveFailures)
         {
-            Task.Factory.StartNew(async () =>
+            Task.Run(async () =>
             {
                 var nbFailures = 0;
                 while (!token.IsCancellationRequested)

--- a/Src/Metrics/Utils/TaskEx.cs
+++ b/Src/Metrics/Utils/TaskEx.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Metrics.Utils
+{
+    internal static class TaskEx
+    {
+        public static readonly Task CompletedTask = Task.FromResult(0);
+    }
+}


### PR DESCRIPTION
Currently, the ActionScheduler uses `Task.Factory.StartNew `with an async body. This has the following caveats:

- Depending on where RunScheduler is called the current scheduler can be used (which could be a synchronization context aware scheduler). Since most of the actions are actually synchronous they could potentially deadlock in certain scenarios.
- It will return `Task<Task>` which can cause troubles if at any point in time someone touches the code and wants to await the task while stopping.

Most likely the issue in point one has never been seen because of the Task.Delay with ConfigureAwait(false) in front of await action. Because the task delay without context capturing will make sure the action is called on the default scheduler (threadpool) (*mostly*)

I still thing Task.Run is the safer choice


