### PR TITLE
enable tracing initialization of HttpEndpoints

### DIFF
--- a/Src/Metrics.Tests/Endpoints/MetricsHttpListenerTests.cs
+++ b/Src/Metrics.Tests/Endpoints/MetricsHttpListenerTests.cs
@@ -85,6 +85,21 @@ namespace Metrics.Tests.Endpoints
             }
         }
 
+        [Fact]
+        public async Task MetricsHttpListener_MetricsConfig_WaitForEndpointInitialization()
+        {
+            using (var config = CreateConfig().WithHttpEndpoint("http://localhost:58888/metricstest/HttpListenerTests/sameendpoint/"))
+            {
+                var whenInitialized = config.WhenEndpointInitialized();
+
+                whenInitialized.IsCompleted.ShouldBeEquivalentTo(false);
+
+                await Task.WhenAny(whenInitialized, Task.Delay(5000));
+
+                whenInitialized.IsCompleted.ShouldBeEquivalentTo(true);
+            }
+        }
+
         private static MetricsConfig CreateConfig()
         {
             var context = new DefaultMetricsContext("http-listener-tests");

--- a/Src/Metrics/MetricsConfig.cs
+++ b/Src/Metrics/MetricsConfig.cs
@@ -268,6 +268,11 @@ namespace Metrics
             return this;
         }
 
+        /// <summary>
+        /// Returns a task which is completed only after HttpEndpoint is initialized
+        /// </summary>
+        public Task WhenEndpointInitialized() => Task.WhenAll(this.httpEndpoints.Values);        
+
         public void Dispose()
         {
             ShutdownHttpEndpoints();


### PR DESCRIPTION
enable tracing initialization of HttpEndpoints using the method 'WhenEndpointInitialized()', which returns a task which will be completed when endpoint is initialized.
Resolving issue #83 

